### PR TITLE
Use environment variables for DB config

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ JSON Processing: Google Gson
 Design Pattern: MVC (Model-View-Controller)
 
 
+## Environment Variables
+
+The application requires the following environment variables to establish a database connection:
+
+| Variable | Description |
+|----------|-------------|
+| `DB_HOST` | Database host name |
+| `DB_PORT` | Database port |
+| `DB_NAME` | Database name |
+| `DB_USER` | Username used for authentication |
+| `DB_PASSWORD` | Password used for authentication |
+
+Ensure these variables are set in your environment before launching the application.
+
 Project Status
 This project is a living work and is under active development. Planned features for the future include:
 Integration with external APIs (e.g., Steam, RAWG.io) for game cover art.

--- a/src/Util/VeritabaniBaglantisi.java
+++ b/src/Util/VeritabaniBaglantisi.java
@@ -6,18 +6,33 @@ import java.sql.SQLException;
 
 public class VeritabaniBaglantisi {
 
-    private static final String HOST = "sql7.freesqldatabase.com";
-    private static final String PORT = "3306";
-    private static final String DB_NAME = "sql7783460";
-    private static final String KULLANICI_ADI = "sql7783460";
-    private static final String SIFRE = "nRwAu5WH44";
+    private static String getEnvOrThrow(String key) {
+        String value = System.getenv(key);
+        if (value == null || value.isEmpty()) {
+            throw new IllegalStateException("Missing required environment variable: " + key);
+        }
+        return value;
+    }
 
-    private static final String URL = "jdbc:mysql://" + HOST + ":" + PORT + "/" + DB_NAME + "?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=CONVERT_TO_NULL";
+    private static String buildUrl() {
+        String host = getEnvOrThrow("DB_HOST");
+        String port = getEnvOrThrow("DB_PORT");
+        String dbName = getEnvOrThrow("DB_NAME");
+        return "jdbc:mysql://" + host + ":" + port + "/" + dbName +
+                "?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=CONVERT_TO_NULL";
+    }
 
     public static Connection baglan() {
         try {
+            String url = buildUrl();
+            String kullaniciAdi = getEnvOrThrow("DB_USER");
+            String sifre = getEnvOrThrow("DB_PASSWORD");
+
             Class.forName("com.mysql.cj.jdbc.Driver");
-            return DriverManager.getConnection(URL, KULLANICI_ADI, SIFRE);
+            return DriverManager.getConnection(url, kullaniciAdi, sifre);
+        } catch (IllegalStateException e) {
+            System.err.println("Veritabanı yapılandırma hatası: " + e.getMessage());
+            return null;
         } catch (ClassNotFoundException | SQLException e) {
             System.err.println("Veritabanına bağlanılamadı! Hata: " + e.getMessage());
             e.printStackTrace();


### PR DESCRIPTION
## Summary
- Replace hard-coded database configuration with environment variable lookups and fail fast when required variables are absent.
- Document expected database environment variables in README.

## Testing
- `javac -d bin $(find src -name "*.java")` *(fails: missing JavaFX packages)*
- `javac -d bin src/Util/VeritabaniBaglantisi.java`


------
https://chatgpt.com/codex/tasks/task_e_688df4c26cec83299376e465466173ee